### PR TITLE
Yolo v5 including Detect() layer

### DIFF
--- a/YOLOv4MLNet/DataStructures/YoloV4BitmapData.cs
+++ b/YOLOv4MLNet/DataStructures/YoloV4BitmapData.cs
@@ -7,7 +7,7 @@ namespace YOLOv4MLNet.DataStructures
     public class YoloV4BitmapData
     {
         [ColumnName("bitmap")]
-        [ImageType(416, 416)]
+        [ImageType(640, 640)]
         public Bitmap Image { get; set; }
 
         [ColumnName("width")]

--- a/YOLOv4MLNet/DataStructures/YoloV4Result.cs
+++ b/YOLOv4MLNet/DataStructures/YoloV4Result.cs
@@ -1,6 +1,6 @@
 ﻿namespace YOLOv4MLNet.DataStructures
 {
-    public class YoloV4Result
+    public class YoloV5Result
     {
         /// <summary>
         /// x1, y1, x2, y2 in page coordinates.
@@ -18,7 +18,7 @@
         /// </summary>
         public float Confidence { get; }
 
-        public YoloV4Result(float[] bbox, string label, float confidence)
+        public YoloV5Result(float[] bbox, string label, float confidence)
         {
             BBox = bbox;
             Label = label;

--- a/YOLOv4MLNet/Program.cs
+++ b/YOLOv4MLNet/Program.cs
@@ -12,7 +12,7 @@ namespace YOLOv4MLNet
     {
         // model is available here:
         // https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/yolov4
-        const string modelPath = @"D:\MachineLearning\Models\yolo_models\yolov5l.onnx";
+        const string modelPath = @"Assets\Models\yolov5s_full_layer.onnx";
 
         const string imageFolder = @"Assets\Images";
 
@@ -29,15 +29,13 @@ namespace YOLOv4MLNet
             // https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/yolov4
 
             // Define scoring pipeline
-            var pipeline = mlContext.Transforms.ResizeImages(inputColumnName: "bitmap", outputColumnName: "images", imageWidth: 640, imageHeight: 640, resizing: ResizingKind.IsoPad)
+            var pipeline = mlContext.Transforms.ResizeImages(inputColumnName: "bitmap", outputColumnName: "images", imageWidth: 640, imageHeight: 640, resizing: ResizingKind.Fill)
                 .Append(mlContext.Transforms.ExtractPixels(outputColumnName: "images", scaleImage: 1f / 255f, interleavePixelColors: false))
                 .Append(mlContext.Transforms.ApplyOnnxModel(
                     shapeDictionary: new Dictionary<string, int[]>()
                     {
                         { "images", new[] { 1, 3, 640, 640 } },
-                        { "output", new[] { 1, 3, 80, 80, 85 } },
-                        { "1313", new[] { 1, 3, 40, 40, 85 } },
-                        { "1333", new[] { 1, 3, 20, 20, 85 } },
+                        { "output", new[] { 1, 25200, 85 } },
                     },
                     inputColumnNames: new[]
                     {
@@ -45,9 +43,7 @@ namespace YOLOv4MLNet
                     },
                     outputColumnNames: new[]
                     {
-                        "output",
-                        "1313",
-                        "1333"
+                        "output"
                     },
                     modelFile: modelPath));
 

--- a/YOLOv4MLNet/YOLOv4MLNet.csproj
+++ b/YOLOv4MLNet/YOLOv4MLNet.csproj
@@ -34,6 +34,9 @@
     <None Update="Assets\Images\ski2.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Assets\Models\yolov5s_full_layer.onnx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- I added a Yolov5s model with `Detect()` layer to test with. 
- I modified the model path to use a relative path instead of an absolute one.
- To use a retrained model you just have to adjust dimensions and class names.
- When creating the pipeline is important to set `interleavePixelColors: false`
- When creating the pipeline is important to set ` resizing: <kind of resizing>` to the correct kind of resizing depending of how the model is trained. The YoloV5s model included in the project works fine with `ResizingKind.Fill`
- It was also important to adjust image size in YoloV4BitmapData.cs
- I did not change any filename to avoid problems, although could be confusing as we are implementing YoloV5. 